### PR TITLE
Added options: Credit payment category warnings, Highlight all negative category balances red

### DIFF
--- a/src/features/check-credit-balances/main.js
+++ b/src/features/check-credit-balances/main.js
@@ -1,0 +1,47 @@
+(function checkCreditBalances_enhancedYNAB() { // give function unique name unlikely to be used by YNAB devs
+   
+	if ( typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' && $('.is-debt-payment-category.is-master-category').length ) {
+
+		var debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
+		var accountName = {};
+		var accountBalance = {};
+		var accountMatch = {};
+		
+		
+		$(debtPaymentCategories).each(function () {
+		  accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title')
+		 
+		  var categoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency').html();
+		  categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') );
+		
+		  $('.nav-account-row').each(function () {
+		
+		    if ( $(this).find('.nav-account-name').prop('title') == accountName ) {
+		      accountMatch = true;
+		      accountBalance = $(this).find('.user-data.currency').html();
+		      accountBalance = Number( accountBalance.replace(/[^\d.-]/g, '') );
+		    }
+		
+		  });
+		
+		  if ( accountMatch ) {
+
+		  	if ( accountBalance + categoryBalance !== 0 ) { // warn if funds do not balance to 0
+
+		      	var $thisCategoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency')
+		      	if ( $thisCategoryBalance.hasClass('positive') ) {
+		      		$thisCategoryBalance.removeClass('positive').addClass('cautious');
+		      	};
+
+		  	};
+		
+		      accountMatch = false; // reset
+		  };
+		});
+
+  	};
+
+	setTimeout(checkCreditBalances_enhancedYNAB, 300);
+
+})();
+

--- a/src/features/highlight-negatives-negative/main.js
+++ b/src/features/highlight-negatives-negative/main.js
@@ -1,0 +1,26 @@
+(function highlightNegativesRed_enhancedYNAB() { // give function unique name unlikely to be used by YNAB devs
+   
+	if ( typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' && $('.budget-table-cell-available-div.user-data').length ) {
+		
+		var availableBalances = $('.budget-table-cell-available-div.user-data');
+		var categoryBalance = {};
+
+		$(availableBalances).each(function () {
+			categoryBalance = $(this).find('.user-data.currency').html(); // get the value
+		  	categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') ); // force data type as number
+		  	
+		
+			if ( categoryBalance < 0 ) {
+				
+			    if ( $(this).find('.user-data.currency').hasClass('cautious') ) {
+			    	$(this).find('.user-data.currency').removeClass('cautious').addClass('negative') 
+			    };
+			};
+
+		});
+
+	}
+	setTimeout(highlightNegativesRed_enhancedYNAB, 300);
+
+})();
+

--- a/src/features/highlight-negatives-negative/main.js
+++ b/src/features/highlight-negatives-negative/main.js
@@ -1,4 +1,4 @@
-(function highlightNegativesRed_enhancedYNAB() { // give function unique name unlikely to be used by YNAB devs
+(function highlightNegativesNegative_enhancedYNAB() { // give function unique name unlikely to be used by YNAB devs
    
 	if ( typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' && $('.budget-table-cell-available-div.user-data').length ) {
 		
@@ -20,7 +20,7 @@
 		});
 
 	}
-	setTimeout(highlightNegativesRed_enhancedYNAB, 300);
+	setTimeout(highlightNegativesNegative_enhancedYNAB, 300);
 
 })();
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,8 @@ function injectScript(path) {
 chrome.storage.sync.get({
   colourBlindMode: false,
   hideAOM: false,
+  checkCreditBalances: false,
+  highlightNegativesNegative: false,
   enableRetroCalculator: true,
   budgetRowsHeight: 0
 }, function(options) {
@@ -28,6 +30,14 @@ chrome.storage.sync.get({
 
   if (options.hideAOM) {
     injectCSS('features/hide-age-of-money/main.css');
+  }
+
+  if (options.highlightNegativesNegative) {
+    injectScript('features/highlight-negatives-negative/main.js');
+  }
+
+  if (options.checkCreditBalances) {
+    injectScript('features/check-credit-balances/main.js');
   }
 
   if (options.enableRetroCalculator) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "YNAB Enhanced",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "UI customisations and tweaks for the web version of YNAB.",
   "icons": {
     "128": "icons/icon128.png"
@@ -22,8 +22,10 @@
   "web_accessible_resources": [
     "features/budget-rows-height/compact.css",
     "features/budget-rows-height/slim.css",
+    "features/check-credit-balances/main.js",
     "features/colour-blind-mode/main.css",
     "features/hide-age-of-money/main.css",
+    "features/highlight-negatives-negative/main.js",
     "features/ynab-4-calculator/main.js"
   ]
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,6 +11,14 @@
   </div>
 
   <div class="option">
+    <label title="Highlight credit category balances with yellow warning highlight if it does not match account balance."><input type="checkbox" id="checkCreditBalances" name="checkCreditBalances">Credit payment category warnings</label>
+  </div>
+
+  <div class="option">
+    <label title="Ensure all negative balances are highlighted red instead of yellow, even with credit card spending."><input type="checkbox" id="highlightNegativesNegative" name="highlightNegativesNegative">Highlight all negative category balances red</label>
+  </div>
+
+  <div class="option">
     <label><input type="checkbox" id="hideAOM" name="hideAOM">Hide Age of Money Calculation</label>
   </div>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,6 +1,8 @@
 function save_options() {
   var colourBlindMode = document.getElementById('colourBlindMode').checked;
   var hideAOM = document.getElementById('hideAOM').checked;
+  var checkCreditBalances = document.getElementById('checkCreditBalances').checked;
+  var highlightNegativesNegative = document.getElementById('highlightNegativesNegative').checked;
   var enableRetroCalculator = document.getElementById('enableRetroCalculator').checked;
   var budgetRowsHeightSelect = document.getElementById('budgetRowsHeight');
   budgetRowsHeight = budgetRowsHeightSelect.options[budgetRowsHeightSelect.selectedIndex].value;
@@ -8,6 +10,8 @@ function save_options() {
   chrome.storage.sync.set({
     colourBlindMode: colourBlindMode,
     hideAOM: hideAOM,
+    checkCreditBalances: checkCreditBalances,
+    highlightNegativesNegative: highlightNegativesNegative,
     enableRetroCalculator: enableRetroCalculator,
     budgetRowsHeight: budgetRowsHeight
   }, function() {
@@ -28,11 +32,15 @@ function restore_options() {
   chrome.storage.sync.get({
     colourBlindMode: false,
     hideAOM: false,
+    checkCreditBalances: false,
+    highlightNegativesNegative: false,
     enableRetroCalculator: true,
     budgetRowsHeight: 0
   }, function(items) {
     document.getElementById('colourBlindMode').checked = items.colourBlindMode;
     document.getElementById('hideAOM').checked = items.hideAOM;
+    document.getElementById('checkCreditBalances').checked = items.checkCreditBalances;
+    document.getElementById('highlightNegativesNegative').checked = items.highlightNegativesNegative;
     document.getElementById('enableRetroCalculator').checked = items.enableRetroCalculator;
     var budgetRowsHeightSelect = document.getElementById('budgetRowsHeight');
     budgetRowsHeightSelect.value = items.budgetRowsHeight;


### PR DESCRIPTION
I have introduced two new options related to displayed category balance colours. The code in each of the main.js files may need to be cleaned up a bit (especially if there is a better way to do it than constantly polling the page every 300ms), but the constant polling with this iteration at least keeps the functionality working when a user navigates to an from their budget view.

I introduced an option that scans the balances in the credit card payments master category and matches them to accounts found in the register. If the total between the two matching account names do not equal zero (but remains a positive number), I force a 'caution' class. This should be useful for PIF credit card users.

I also added an option that scans the available balances in the budget and if the value of the balance is less than zero, I force the 'negative' class. Now any negative balance will use the 'negative' class, replacing instances where it might be 'cautious' (yellow) due to credit card overspending instead of cash overspending. 

Both options can work independently of each other and should not conflict with the colourblind mode.