### PR TITLE
Alternate color for credit card overspending

### DIFF
--- a/src/features/overspending-alternate-color/main.css
+++ b/src/features/overspending-alternate-color/main.css
@@ -1,0 +1,3 @@
+.budget-table-row.is-sub-category > .budget-table-cell-available .credit-overspending {
+    background-color: #d33c2d !important;
+}

--- a/src/features/overspending-alternate-color/main.js
+++ b/src/features/overspending-alternate-color/main.js
@@ -1,0 +1,29 @@
+function alternateOverspendingColor() {
+    var elements = document.getElementsByClassName('cautious');
+    n = elements.length;
+    for (var i = 0; i < n; i++) {
+        var e = elements[i];
+        if(e.textContent.substr(0, 1) == '-') {
+            e.className = e.className + " credit-overspending";
+        }
+    }
+}
+
+function checkState() {
+    var classes = document.body.classList;
+    n = classes.length;
+    loading = false;
+    for (var i = 0; i < n; i++) {
+        if (classes[i] == 'is-init-loading') {
+            loading = true;
+            break;
+        }
+    }
+    if (!loading) {
+        alternateOverspendingColor();
+    } else {
+        setTimeout(checkState, 50);
+    }
+}
+
+setTimeout(checkState, 50);

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,8 @@ chrome.storage.sync.get({
   colourBlindMode: false,
   hideAOM: false,
   enableRetroCalculator: true,
-  budgetRowsHeight: 0
+  budgetRowsHeight: 0,
+  markOverspendingRed: false
 }, function(options) {
 
   if (options.colourBlindMode) {
@@ -39,5 +40,10 @@ chrome.storage.sync.get({
   }
   else if (options.budgetRowsHeight == 2) {
     injectCSS('features/budget-rows-height/slim.css');
+  }
+
+  if (options.markOverspendingRed) {
+    injectScript('features/overspending-alternate-color/main.js');
+    injectCSS('features/overspending-alternate-color/main.css');
   }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,8 @@
     "features/budget-rows-height/slim.css",
     "features/colour-blind-mode/main.css",
     "features/hide-age-of-money/main.css",
+    "features/overspending-alternate-color/main.css",
+    "features/overspending-alternate-color/main.js",
     "features/ynab-4-calculator/main.js"
   ]
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -29,6 +29,10 @@
     </label>
   </div>
 
+  <div class="option">
+    <label><input type="checkbox" id="markOverspendingRed" name="markOverspendingRed">Mark credit overspending red instead of orange</label>
+  </div>
+
   <div id="status"></div>
 
   <button id="save" class="save">Save</button>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,13 +3,15 @@ function save_options() {
   var hideAOM = document.getElementById('hideAOM').checked;
   var enableRetroCalculator = document.getElementById('enableRetroCalculator').checked;
   var budgetRowsHeightSelect = document.getElementById('budgetRowsHeight');
-  budgetRowsHeight = budgetRowsHeightSelect.options[budgetRowsHeightSelect.selectedIndex].value;
+  var budgetRowsHeight = budgetRowsHeightSelect.options[budgetRowsHeightSelect.selectedIndex].value;
+  var markOverspendingRed = document.getElementById('markOverspendingRed').checked;
 
   chrome.storage.sync.set({
     colourBlindMode: colourBlindMode,
     hideAOM: hideAOM,
     enableRetroCalculator: enableRetroCalculator,
-    budgetRowsHeight: budgetRowsHeight
+    budgetRowsHeight: budgetRowsHeight,
+    markOverspendingRed: markOverspendingRed
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -29,13 +31,15 @@ function restore_options() {
     colourBlindMode: false,
     hideAOM: false,
     enableRetroCalculator: true,
-    budgetRowsHeight: 0
+    budgetRowsHeight: 0,
+    markOverspendingRed: false
   }, function(items) {
     document.getElementById('colourBlindMode').checked = items.colourBlindMode;
     document.getElementById('hideAOM').checked = items.hideAOM;
     document.getElementById('enableRetroCalculator').checked = items.enableRetroCalculator;
     var budgetRowsHeightSelect = document.getElementById('budgetRowsHeight');
     budgetRowsHeightSelect.value = items.budgetRowsHeight;
+    document.getElementById('markOverspendingRed').checked = items.markOverspendingRed;
   });
 }
 


### PR DESCRIPTION
This option will turn credit card overspending red instead of orange.