### PR TITLE
Remove zero categories from cover overbudgeting

### DIFF
--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -1,0 +1,12 @@
+function removeZeroCategoriesFromCoverOverbudgeting() {
+  var coverOverbudgetingCategories = $( "fieldset>.options-shown>.ynab-select-options" ).children('li');
+  coverOverbudgetingCategories.each(function(i) { 
+    var t = $(this).text(); // Category balance text.
+    var categoryBalance = parseInt(t.substr(t.length - t.indexOf(":") + 2).replace( /\D/g, ''))
+    if (categoryBalance == 0) {
+      $(this).remove();
+    }
+  });
+}
+
+setInterval(removeZeroCategoriesFromCoverOverbudgeting, 50);

--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -9,4 +9,4 @@ function removeZeroCategoriesFromCoverOverbudgeting() {
   });
 }
 
-setInterval(removeZeroCategoriesFromCoverOverbudgeting, 50);
+setInterval(removeZeroCategoriesFromCoverOverbudgeting, 250);

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ chrome.storage.sync.get({
   colourBlindMode: false,
   hideAOM: false,
   enableRetroCalculator: true,
+  removeZeroCategories: true,
   budgetRowsHeight: 0,
   categoryPopupWidth: 0
 }, function(options) {
@@ -33,6 +34,10 @@ chrome.storage.sync.get({
 
   if (options.enableRetroCalculator) {
     injectScript('features/ynab-4-calculator/main.js');
+  }
+
+  if (options.removeZeroCategories) {
+    injectScript('features/remove-zero-categories/main.js');
   }
 
   if (options.budgetRowsHeight == 1) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,7 @@
     "features/category-popup-width/large.css",
     "features/colour-blind-mode/main.css",
     "features/hide-age-of-money/main.css",
-    "features/ynab-4-calculator/main.js"
+    "features/ynab-4-calculator/main.js",
+    "features/remove-zero-categories/main.js"
   ]
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -19,6 +19,10 @@
   </div>
 
   <div class="option">
+    <label><input type="checkbox" id="removeZeroCategories" name="removeZeroCategories">Remove zero categories when cover overbudgeting</label>
+  </div>
+
+  <div class="option">
     <label>
         Height of budget rows
         <select name="budgetRowsHeight" id="budgetRowsHeight">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -2,6 +2,7 @@ function save_options() {
   var colourBlindMode = document.getElementById('colourBlindMode').checked;
   var hideAOM = document.getElementById('hideAOM').checked;
   var enableRetroCalculator = document.getElementById('enableRetroCalculator').checked;
+  var removeZeroCategories = document.getElementById('removeZeroCategories').checked;
   var budgetRowsHeightSelect = document.getElementById('budgetRowsHeight');
   budgetRowsHeight = budgetRowsHeightSelect.options[budgetRowsHeightSelect.selectedIndex].value;
   var categoryPopupWidthSelect = document.getElementById('categoryPopupWidth');
@@ -11,6 +12,7 @@ function save_options() {
     colourBlindMode: colourBlindMode,
     hideAOM: hideAOM,
     enableRetroCalculator: enableRetroCalculator,
+    removeZeroCategories: removeZeroCategories,
     budgetRowsHeight: budgetRowsHeight,
     categoryPopupWidth: categoryPopupWidth
   }, function() {
@@ -32,12 +34,14 @@ function restore_options() {
     colourBlindMode: false,
     hideAOM: false,
     enableRetroCalculator: true,
+    removeZeroCategories: true,
     budgetRowsHeight: 0,
     categoryPopupWidth: 0
   }, function(items) {
     document.getElementById('colourBlindMode').checked = items.colourBlindMode;
     document.getElementById('hideAOM').checked = items.hideAOM;
     document.getElementById('enableRetroCalculator').checked = items.enableRetroCalculator;
+    document.getElementById('removeZeroCategories').checked = items.removeZeroCategories;
     var budgetRowsHeightSelect = document.getElementById('budgetRowsHeight');
     budgetRowsHeightSelect.value = items.budgetRowsHeight;
     var categoryPopupWidthSelect = document.getElementById('categoryPopupWidth');


### PR DESCRIPTION
During overbudgeting after click on the top red -XXX button popup with words "Cover this overbudgeting with:" appears. It can't be done with zero categories so I removed them.

But I'm not shure if "setInterval(removeZeroCategoriesFromCoverOverbudgeting, 50);" is apropriate way to do so. However it works fine.

Screwed this pull request with the commit of the other mine pull request. Should I rework this or you'll handle?