### PR TITLE
Option to toggle split line-item visibility

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,9 +21,6 @@ function injectScript(path) {
 injectCSS('features/collapse-budget-groups/main.css');
 injectScript('features/collapse-budget-groups/main.js');
 
-// Toggle Splits button
-injectScript('features/toggle-splits/main.js');
-
 chrome.storage.sync.get({
   colourBlindMode: false,
   hideAOM: false,
@@ -35,7 +32,8 @@ chrome.storage.sync.get({
   categoryActivityPopupWidth: 0,
   budgetRowsHeight: 0,
   moveMoneyDialog: false,
-  moveMoneyAutocomplete: true
+  moveMoneyAutocomplete: true,
+  toggleSplits: false
 }, function(options) {
 
   if (options.colourBlindMode) {
@@ -83,5 +81,9 @@ chrome.storage.sync.get({
   if (options.moveMoneyAutocomplete) {
     injectCSS('features/move-money-autocomplete/main.css');
     injectScript('features/move-money-autocomplete/main.js');
+  }
+
+  if (options.toggleSplits) {
+    injectScript('features/toggle-splits/main.js');
   }
 });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -40,6 +40,10 @@
   </div>
 
   <div class="option">
+    <label><input type="checkbox" id="toggleSplits" name="toggleSplits">Enable visibility toggling of split transactions</label>
+  </div>
+
+  <div class="option">
     <label>
         Height of budget rows
         <select name="budgetRowsHeight" id="budgetRowsHeight">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -19,6 +19,7 @@ function save_options() {
   categoryActivityPopupWidth = categoryActivityPopupWidthSelect.options[categoryActivityPopupWidthSelect.selectedIndex].value;
   var moveMoneyDialog = false; // Kevin: Hidden until issue #18 is resolved document.getElementById('moveMoneyDialog').checked;
   var moveMoneyAutocomplete = document.getElementById('moveMoneyAutocomplete').checked;
+  var toggleSplits = document.getElementById('toggleSplits').checked;
 
   chrome.storage.sync.set({
     colourBlindMode: colourBlindMode,
@@ -30,7 +31,8 @@ function save_options() {
     budgetRowsHeight: budgetRowsHeight,
     categoryActivityPopupWidth: categoryActivityPopupWidth,
     moveMoneyDialog: moveMoneyDialog,
-    moveMoneyAutocomplete: moveMoneyAutocomplete
+    moveMoneyAutocomplete: moveMoneyAutocomplete,
+    toggleSplits: toggleSplits
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -57,7 +59,8 @@ function restore_options() {
     budgetRowsHeight: 0,
     categoryActivityPopupWidth: 0,
     budgetRowsHeight: 0,
-    moveMoneyAutocomplete: false
+    moveMoneyAutocomplete: false,
+    toggleSplits: false
   }, function(items) {
     document.getElementById('colourBlindMode').checked = items.colourBlindMode;
     document.getElementById('hideAOM').checked = items.hideAOM;
@@ -71,6 +74,7 @@ function restore_options() {
     categoryActivityPopupWidthSelect.value = items.categoryActivityPopupWidth;
     // Kevin: Hidden until issue #18 is resolved document.getElementById('moveMoneyDialog').checked = items.moveMoneyDialog;
     document.getElementById('moveMoneyAutocomplete').checked = items.moveMoneyAutocomplete;
+    document.getElementById('toggleSplits').checked = items.toggleSplits;
   });
 }
 


### PR DESCRIPTION
Added configuration option to toggle visibility of splits and set its default to unchecked. Completes this Trello card: https://trello.com/c/ss1kRTYD/72-ensure-the-splits-button-and-collapse-button-are-options-that-can-be-configured