### PR TITLE
Added a more reliable css selector and fixed parsing bug

### DIFF
--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -4,7 +4,7 @@
     var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
     coverOverbudgetingCategories.each(function(i) {
       var t = $(this).text(); // Category balance text.
-      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d]/g, ''));
+      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
       if (categoryBalance <= 0) {
         $(this).remove();
       }

--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -1,10 +1,10 @@
 (function removeZeroCategoriesFromCoverOverbudgeting() {
 
   if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined') {
-    var coverOverbudgetingCategories = $( "fieldset>.options-shown>.ynab-select-options" ).children('li');
+    var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
     coverOverbudgetingCategories.each(function(i) {
       var t = $(this).text(); // Category balance text.
-      var categoryBalance = parseInt(t.substr(t.length - t.indexOf(":") + 2).replace( /\D/g, ''))
+      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
       if (categoryBalance <= 0) {
         $(this).remove();
       }

--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -4,7 +4,7 @@
     var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
     coverOverbudgetingCategories.each(function(i) {
       var t = $(this).text(); // Category balance text.
-      var categoryBalance = parseInt(t.substr(t.length - t.indexOf(":") + 2).replace( /\D/g, ''))
+      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d]/g, ''));
       if (categoryBalance <= 0) {
         $(this).remove();
       }

--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -1,10 +1,10 @@
 (function removeZeroCategoriesFromCoverOverbudgeting() {
 
   if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined') {
-    var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
+    var coverOverbudgetingCategories = $( "fieldset>.options-shown>.ynab-select-options" ).children('li');
     coverOverbudgetingCategories.each(function(i) {
       var t = $(this).text(); // Category balance text.
-      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
+      var categoryBalance = parseInt(t.substr(t.length - t.indexOf(":") + 2).replace( /\D/g, ''))
       if (categoryBalance <= 0) {
         $(this).remove();
       }

--- a/src/features/remove-zero-categories/main.js
+++ b/src/features/remove-zero-categories/main.js
@@ -1,7 +1,7 @@
 (function removeZeroCategoriesFromCoverOverbudgeting() {
 
   if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined') {
-    var coverOverbudgetingCategories = $( "fieldset>.options-shown>.ynab-select-options" ).children('li');
+    var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
     coverOverbudgetingCategories.each(function(i) {
       var t = $(this).text(); // Category balance text.
       var categoryBalance = parseInt(t.substr(t.length - t.indexOf(":") + 2).replace( /\D/g, ''))


### PR DESCRIPTION
Replaced 'fieldset' with '.modal-budget-overspending' which has a higher
chance of remaining consistent in production code. 

Fixed parsing error that would include dollars values stored in the
title of a category, causing them to persist even if they contained a $0
balance. (Example "Christmas $750: $0" would be previously parsed as '7500' instead of '0')

I did accidentally commit the replace() function that ignore the negative sign, and I'm not sure why git thinks I replaced all 30 lines of code, but it should be harmless.