### PR TITLE
accountDisplayDensity

### DIFF
--- a/src/features/accounts-display-density/compact.css
+++ b/src/features/accounts-display-density/compact.css
@@ -1,12 +1,7 @@
-
 .nav-account-row {
      line-height: normal  !important;
      padding: 0.025em 0 !important;
     
-}
-
-.nav-account-name {
-    padding-left: .15em   !important;
 }
 
 .accounts-header-total-inner-label {

--- a/src/features/accounts-display-density/compact.css
+++ b/src/features/accounts-display-density/compact.css
@@ -1,0 +1,14 @@
+
+.nav-account-row {
+     line-height: normal  !important;
+     padding: 0.025em 0 !important;
+    
+}
+
+.nav-account-name {
+    padding-left: .15em   !important;
+}
+
+.accounts-header-total-inner-label {
+    height: 24px;
+}

--- a/src/features/accounts-display-density/slim.css
+++ b/src/features/accounts-display-density/slim.css
@@ -1,0 +1,13 @@
+.nav-account-row {
+     line-height: normal  !important;
+     padding: 0.01em 0 !important;
+     font-size: .85em !important;
+}
+
+.nav-account-name {
+    padding-left: 0px;
+}
+
+.accounts-header-total-inner-label {
+    height: 24px;
+}

--- a/src/features/accounts-display-density/slim.css
+++ b/src/features/accounts-display-density/slim.css
@@ -4,10 +4,6 @@
      font-size: .85em !important;
 }
 
-.nav-account-name {
-    padding-left: 0px;
-}
-
 .accounts-header-total-inner-label {
     height: 24px;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,8 @@ chrome.storage.sync.get({
   moveMoneyDialog: false,
   moveMoneyAutocomplete: true,
   toggleSplits: false,
-  accountsSelectedTotal: false
+  accountsSelectedTotal: false,
+  accountsDisplayDensity: 0,
 }, function(options) {
 
   if (options.collapseExpandBudgetGroups) {
@@ -118,5 +119,12 @@ chrome.storage.sync.get({
   }
   else if (options.reconciledTextColor == 4) {
     injectCSS('features/distinguish-reconciled-transactions/chance.css');
+  }
+  
+  if (options.accountsDisplayDensity == 1) {
+    injectCSS('features/accounts-display-density/compact.css');
+  }
+  else if (options.accountsDisplayDensity == 2) {
+    injectCSS('features/accounts-display-density/slim.css');
   }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,6 +44,8 @@
     "features/toggle-splits/main.js",
     "features/move-money-autocomplete/main.css",
     "features/move-money-autocomplete/main.js",
-    "features/ynab-4-calculator/main.js"
+    "features/ynab-4-calculator/main.js",
+    "features/accounts-display-density/slim.css",
+    "features/accounts-display-density/compact.css"
   ]
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -56,6 +56,17 @@
 
   <div class="option">
     <label>
+        Accounts display density
+        <select name="accountsDisplayDensity" id="accountsDisplayDensity">
+            <option value="0">Default</option>
+            <option value="1">Compact</option>
+            <option value="2">Slim</option>
+        </select>
+    </label>
+  </div>
+  
+  <div class="option">
+    <label>
         Height of budget rows
         <select name="budgetRowsHeight" id="budgetRowsHeight">
             <option value="0">Default</option>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -25,7 +25,9 @@ function save_options() {
   var moveMoneyAutocomplete = document.getElementById('moveMoneyAutocomplete').checked;
   var toggleSplits = document.getElementById('toggleSplits').checked;
   var accountsSelectedTotal = document.getElementById('accountsSelectedTotal').checked;
-
+  var accountsDisplayDensitySelect = document.getElementById('accountsDisplayDensity');
+  accountsDisplayDensity = accountsDisplayDensitySelect.options[accountsDisplayDensitySelect.selectedIndex].value;
+  
   chrome.storage.sync.set({
     collapseExpandBudgetGroups: collapseExpandBudgetGroups,
     collapseSideMenu: collapseSideMenu,
@@ -41,7 +43,8 @@ function save_options() {
     moveMoneyDialog: moveMoneyDialog,
     moveMoneyAutocomplete: moveMoneyAutocomplete,
     toggleSplits: toggleSplits,
-    accountsSelectedTotal: accountsSelectedTotal
+    accountsSelectedTotal: accountsSelectedTotal,
+    accountsDisplayDensity: accountsDisplayDensity
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -73,7 +76,8 @@ function restore_options() {
     moveMoneyAutocomplete: false,
     toggleSplits: false,
     accountsSelectedTotal: false,
-    reconciledTextColor: 0
+    reconciledTextColor: 0,
+    accountsDisplayDensity: 0
   }, function(items) {
     document.getElementById('collapseExpandBudgetGroups').checked = items.collapseExpandBudgetGroups;
     document.getElementById('collapseSideMenu').checked = items.collapseSideMenu;
@@ -93,6 +97,8 @@ function restore_options() {
     document.getElementById('moveMoneyAutocomplete').checked = items.moveMoneyAutocomplete;
     document.getElementById('toggleSplits').checked = items.toggleSplits;
     document.getElementById('accountsSelectedTotal').checked = items.accountsSelectedTotal;
+    var accountsDisplayDensitySelect = document.getElementById('accountsDisplayDensity');
+    accountsDisplayDensitySelect.value = items.accountsDisplayDensity;
   });
 }
 


### PR DESCRIPTION
Option to resize the display in the accounts panel.  Helpful for those users with a lot of accounts who want to see them all with out scrolling or with out ellipses on there moderately sized account names.

Options: Default; Compact; Slim

The compact and slim options also fix a small display error in the account header where the account name are cut off.  Visible when accounts use characters like lower case g.